### PR TITLE
update alm-examples to remove namespace

### DIFF
--- a/deploy/olm-catalog/resource-locker-operator/0.1.2/resource-locker-operator.v0.1.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/resource-locker-operator/0.1.2/resource-locker-operator.v0.1.2.clusterserviceversion.yaml
@@ -17,8 +17,7 @@ metadata:
                   "apiVersion": "v1",
                   "kind": "ResourceQuota",
                   "metadata": {
-                    "name": "small-size",
-                    "namespace": "resource-locker-test"
+                    "name": "small-size"
                   },
                   "spec": {
                     "hard": {
@@ -49,8 +48,7 @@ metadata:
                 "targetObjectRef": {
                   "apiVersion": "v1",
                   "kind": "ServiceAccount",
-                  "name": "test",
-                  "namespace": "resource-locker-test"
+                  "name": "test"
                 },
                 "patchTemplate": "metadata:\n  annotations:\n    hello: bye\n",
                 "patchType": "application/strategic-merge-patch+json"
@@ -74,7 +72,6 @@ metadata:
                   "apiVersion": "v1",
                   "kind": "ServiceAccount",
                   "name": "test",
-                  "namespace": "resource-locker-test"
                 },
                 "patchTemplate": "metadata:\n  annotations:\n    {{ (index . 0).metadata.name }}: {{ (index . 1).metadata.name }}\n",
                 "patchType": "application/strategic-merge-patch+json",
@@ -87,8 +84,7 @@ metadata:
                   {
                     "apiVersion": "v1",
                     "kind": "ServiceAccount",
-                    "name": "default",
-                    "namespace": "resource-locker-test"
+                    "name": "default"
                   }
                 ]
               }


### PR DESCRIPTION
In the `alm-examples` spec item of the CSV, the provided samples reference a namespace that doesn't exist. While there's likely to be setup required in most cases where `ResourceLocker` is used, it feels like the namespace where the sample references should be the namespace the user's logged into via the dashboard.