### PR TITLE
add generic alm-example to olm-catalog 0.1.3 placeholders

### DIFF
--- a/deploy/crds/redhatcop.redhat.io_v1alpha1_complexpatch.yaml
+++ b/deploy/crds/redhatcop.redhat.io_v1alpha1_complexpatch.yaml
@@ -1,0 +1,26 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  name: example-patch-complex
+spec:
+  serviceAccountRef:
+    name: default
+  patches:
+  - targetObjectRef:
+      apiVersion: v1
+      kind: ServiceAccount
+      name: test
+      namespace: resource-locker-test
+    patchTemplate: |
+      metadata:
+        annotations:
+          {{ (index . 0).metadata.name }}: {{ (index . 1).metadata.name }}
+    patchType: application/strategic-merge-patch+json
+    sourceObjectRefs:
+    - apiVersion: v1
+      kind: Namespace
+      name: resource-locker-test
+    - apiVersion: v1
+      kind: ServiceAccount
+      name: default
+      namespace: resource-locker-test

--- a/deploy/crds/redhatcop.redhat.io_v1alpha1_lockedresource_cr.yaml
+++ b/deploy/crds/redhatcop.redhat.io_v1alpha1_lockedresource_cr.yaml
@@ -1,0 +1,16 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  name: example-locked-resource
+spec:
+  resources:
+  - object:
+      apiVersion: v1
+      data:
+        isLocked: dHJ1ZQ==
+      kind: Secret
+      metadata:
+        name: simple-locked-secret
+      type: Opaque
+  serviceAccountRef:
+    name: resource-locker-operator

--- a/deploy/crds/redhatcop.redhat.io_v1alpha1_resourcelocker_cr.yaml
+++ b/deploy/crds/redhatcop.redhat.io_v1alpha1_resourcelocker_cr.yaml
@@ -1,7 +1,0 @@
-apiVersion: redhatcop.redhat.io/v1alpha1
-kind: ResourceLocker
-metadata:
-  name: example-resourcelocker
-spec:
-  # Add fields here
-  size: 3

--- a/deploy/crds/redhatcop.redhat.io_v1alpha1_simplepatch.yaml
+++ b/deploy/crds/redhatcop.redhat.io_v1alpha1_simplepatch.yaml
@@ -1,0 +1,18 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  name: example-patch-simple
+spec:
+  serviceAccountRef:
+    name: default
+  patches:
+  - targetObjectRef:
+      apiVersion: v1
+      kind: ServiceAccount
+      name: test
+      namespace: resource-locker-test
+    patchTemplate: |
+      metadata:
+        annotations:
+          hello: bye
+    patchType: application/strategic-merge-patch+json

--- a/deploy/olm-catalog/README.md
+++ b/deploy/olm-catalog/README.md
@@ -18,13 +18,13 @@ update the [`deploy/operator.yaml`](./deploy/operator.yaml) with the image tag o
 If you creating the csv for the first time run the following:
 
 ```shell
-operator-sdk olm-catalog gen-csv --csv-version $new_version --csv-channel alpha --default-channel
+operator-sdk generate csv --csv-version $new_version --csv-channel alpha --default-channel
 ```
 
 If you are updating run the following:
 
 ```shell
-operator-sdk olm-catalog gen-csv --csv-version $new_version --from-version $old_version --update-crds
+operator-sdk generate csv --csv-version $new_version --from-version $old_version --update-crds
 ```
 
 verify the created csv:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -31,6 +31,7 @@ rules:
   resources:
   - configmaps
   - pods
+  - secrets
   verbs:
   - "*"  
 #Metrics  


### PR DESCRIPTION
Nearly there, @raffaelespazzoli - thanks so much for your help resolving [this](https://bugzilla.redhat.com/show_bug.cgi?id=1794821)!

The gitdiff reflects that I created new files, but understand that I simply took the directory structure for the `olm-catalog/resource-locker-operator/0.1.2` and copied it over to `0.1.3`, and then made the following changes:

1. Bumped all version references to `0.1.3`
2. In the **ClusterServiceVersion**, I added the **Secret** object to the permission list. That will translate to a the **Role** which is given to the operator's **ServiceAccount** being updated when installed via OLM in OpenShift. [Link](https://github.com/redhat-cop/resource-locker-operator/pull/19/files#diff-3f8b290ae0a146a1e01b7192f1759214R202)
3. In the **ClusterServiceVersion**, I updated all version references from previous `0.1.2` to `0.1.3`.
4. In the **ClusterServiceVersion**, I removed the original `test-simple-resource` CR and replaced it with one that can properly be created out-of-the-box with no changes required by the end user. [Link](https://github.com/redhat-cop/resource-locker-operator/pull/19/files#diff-3f8b290ae0a146a1e01b7192f1759214R8)

The **CustomResourceDefinition** has not been changed.

### What needs to be done
This merely stages the bundle data that's needed to update the operator in https://github.com/operator-framework/community-operators but the images still need to be built, published, and everything needs to be merged over there as well whenever you have time!

### Goal of this PR
Final piece necessary to fix this [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1794821). 🎉 

Allows an end-user to create an instance of a **ResourceLocker** successfully. It uses the operator's default **ServiceAccount** (`resource-locker-operator`) which is not a best practice, but should be ok for demonstration purposes. That **ServiceAccount** has the ability to create secrets with this PR, as well as list them at the cluster scope which is a requirement (this piece was already in place, no change happens here re: the deployed **ClusterRole** or the `clusterPermissions` CSV spec item).