### PR TITLE
Events patching added to ClusterRole

### DIFF
--- a/charts/resource-locker-operator/templates/role.yaml
+++ b/charts/resource-locker-operator/templates/role.yaml
@@ -24,7 +24,9 @@ rules:
   resources:
   - events
   verbs:
+  - create
   - patch
+  - update
 ---  
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/resource-locker-operator/templates/role.yaml
+++ b/charts/resource-locker-operator/templates/role.yaml
@@ -18,7 +18,13 @@ rules:
   verbs:
   - get
   - list
-  - watch  
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
 ---  
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -18,7 +18,13 @@ rules:
   verbs:
   - get
   - list
-  - watch   
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -24,7 +24,9 @@ rules:
   resources:
   - events
   verbs:
+  - create
   - patch
+  - update
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
If resource labels are to be patched, resource-locker-operator required capability to patch events.

Error observed:
```
events "test-complex-patch.162053c2da87466b" is forbidden: User "system:serviceaccount:resource-locker-operator:resource-locker-operator" cannot patch resource "events" in API group "" in the namespace "resource-locker-test"'
```